### PR TITLE
Remove --quiet flag from docker command

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -47,7 +47,7 @@ func gokiIsDead(id int) (bool, error) {
 	var deadGokiList []string = []string{}
 
 	// Get list of running container that related to Goki.
-	c := exec.Command("docker", "ps", "-qf", "label="+gokiResourceLabel, "--format", "{{.Names}}")
+	c := exec.Command("docker", "ps", "-f", "label="+gokiResourceLabel, "--format", "{{.Names}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker ps command failed: %v\n", string(output))
@@ -63,7 +63,7 @@ func gokiIsDead(id int) (bool, error) {
 	}
 
 	// Get list of stopped containers that related to Goki.
-	c = exec.Command("docker", "ps", "-aqf", "label="+gokiResourceLabel, "--format", "{{.Names}}")
+	c = exec.Command("docker", "ps", "-af", "label="+gokiResourceLabel, "--format", "{{.Names}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker ps command failed: %v\n", string(output))

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -153,7 +153,7 @@ func checkDocker() error {
 }
 
 func checkGokiContainer() error {
-	c := exec.Command("docker", "ps", "-aqf", "label="+gokiResourceLabel, "--format", "{{.ID}} : {{.Names}}")
+	c := exec.Command("docker", "ps", "-af", "label="+gokiResourceLabel, "--format", "{{.ID}} : {{.Names}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker ps commad failed: %v\n", string(output))
@@ -169,7 +169,7 @@ func checkGokiContainer() error {
 }
 
 func checkGokiNetwork() error {
-	c := exec.Command("docker", "network", "ls", "-qf", "label="+gokiResourceLabel, "--format", "{{.ID}} : {{.Name}}")
+	c := exec.Command("docker", "network", "ls", "-f", "label="+gokiResourceLabel, "--format", "{{.ID}} : {{.Name}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker network ls commad failed: %v\n", string(output))
@@ -184,7 +184,7 @@ func checkGokiNetwork() error {
 }
 
 func checkGokiVolume() error {
-	c := exec.Command("docker", "volume", "ls", "-qf", "label="+gokiResourceLabel, "--format", "{{.Name}}")
+	c := exec.Command("docker", "volume", "ls", "-f", "label="+gokiResourceLabel, "--format", "{{.Name}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker volume ls command failed: %v\n", string(output))

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -91,7 +91,7 @@ func deleteGokiContainers() error {
 	var deadGokiList []string = []string{}
 
 	// Get list of running container that related to Goki.
-	c := exec.Command("docker", "ps", "-qf", "label="+gokiResourceLabel, "--format", "{{.Names}}")
+	c := exec.Command("docker", "ps", "-f", "label="+gokiResourceLabel, "--format", "{{.Names}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker ps command failed: %v\n", string(output))
@@ -113,7 +113,7 @@ func deleteGokiContainers() error {
 	}
 
 	// Get list of stopped containers to remove them.
-	c = exec.Command("docker", "ps", "-aqf", "label="+gokiResourceLabel, "--format", "{{.Names}}")
+	c = exec.Command("docker", "ps", "-af", "label="+gokiResourceLabel, "--format", "{{.Names}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker ps command failed: %v\n", string(output))
@@ -150,7 +150,7 @@ func deleteGokiNetwork() error {
 	var gokiNetworkName string
 
 	// Get goki network name.
-	c := exec.Command("docker", "network", "ls", "-qf", "label="+gokiResourceLabel, "--format", "{{.Name}}")
+	c := exec.Command("docker", "network", "ls", "-f", "label="+gokiResourceLabel, "--format", "{{.Name}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker network ls command failed: %v\n", string(output))
@@ -184,7 +184,7 @@ func deleteGokiVolume() error {
 	var gokiVolumeList []string = []string{}
 
 	// Get list of goki volume.
-	c := exec.Command("docker", "volume", "ls", "-qf", "label="+gokiResourceLabel, "--format", "{{.Name}}")
+	c := exec.Command("docker", "volume", "ls", "-f", "label="+gokiResourceLabel, "--format", "{{.Name}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker volume ls command failed: %v\n", string(output))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -52,7 +52,7 @@ func getNumberOfContainers() (int, error) {
 	var gokiList []string = []string{}
 
 	// Get list of stopped containers to remove them.
-	c := exec.Command("docker", "ps", "-aqf", "label="+gokiResourceLabel, "--format", "{{.Names}}")
+	c := exec.Command("docker", "ps", "-af", "label="+gokiResourceLabel, "--format", "{{.Names}}")
 
 	if output, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "docker ps command failed: %v\n", string(output))


### PR DESCRIPTION
Recently, it seems that the `docker` command returns the following WARNING messages if we set both `--format` and `--quiet`.
Goki expects only container names or IDs as a result of the `docker ps` command (Goki cannot handle WARNING messages properly...)
So, I just removed the `--quiet` flag.